### PR TITLE
Add referring addons list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 If you want to use this template in your addon, then don't forget to change the path to the textures
 "Interface\AddOns\" ... "\CircleCooldownTemplate\Cooldown\CircleCooldown"
+
+Addons that references this lib:
+https://github.com/BannZay/LoseControl


### PR DESCRIPTION
This repository lacks of examples. I added the list and a single entry of referring addons list. This way people could learn addons built using this lib to learn how to use the lib itself.