### PR TITLE
Update CircleCooldownTemplate.lua

### DIFF
--- a/CircleCooldownTemplate/CircleCooldownTemplate.lua
+++ b/CircleCooldownTemplate/CircleCooldownTemplate.lua
@@ -307,6 +307,6 @@ function CircleCooldownFrame_OnUpdate(self, elapsed)
             self.Bling.texture.Anim:Play();
         end
     else
-        self:Hide();
+        --self:Hide();
     end
 end


### PR DESCRIPTION
анимация пропадает раньше иконки, соответственно происходит кратковременное "моргание" при переходе с тёмной иконки на полностью светлую, что выглядит отвратительно.